### PR TITLE
Allow higher version of polyparse because of GHC 7.10.1

### DIFF
--- a/xdot.cabal
+++ b/xdot.cabal
@@ -33,7 +33,7 @@ Library
                  gtk >= 0.12 && < 0.14,
                  graphviz >= 2999.16 && < 2999.18,
                  text >= 0.11 && < 1.3,
-                 polyparse >= 1.8 && < 1.10
+                 polyparse >= 1.8 && < 1.12
   Hs-source-dirs: src/
   Ghc-options: -Wall -fno-warn-unused-do-bind
 


### PR DESCRIPTION
A higher version of polyparse is needed for GHC 7.10.1.