### PR TITLE
Support upto GHC 8.6.5 and bump version to 0.3.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,65 +1,66 @@
-# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
-# Caching has been removed because it somehow did not work.
-language: c
-sudo: false
+# See: https://docs.haskellstack.org/en/stable/travis_ci/
+
+sudo: true
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - ~/.stack
+  - ~/.local
+  - ~/.stack-work-cache
+  apt: true
+
+git:
+  submodules: false
+
+before_install:
+# Install GTK
+- sudo apt-get update
+- sudo apt-get -y install libgtk-3-dev
+# Download and unpack the stack executable
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+- which stack
+- ~/.local/bin/stack --version
+# ghc
+- export PATH=/opt/ghc/$GHCVER/bin:$PATH
+
+install:
+ - stack setup
+ - stack exec -- ghc --version
+
+script:
+ - stack --no-terminal --skip-ghc-check build
+ - stack --no-terminal --skip-ghc-check sdist
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.4.1
-      compiler: ": #GHC 7.4.1"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.1,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.4.2
-      compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.6.1
-      compiler: ": #GHC 7.6.1"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.1,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.6.2
-      compiler: ": #GHC 7.6.2"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.2,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.6.3
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.3
-      compiler: ": #GHC 7.8.3"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.3,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.1
-      compiler: ": #GHC 7.10.1"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.1,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.2
-      compiler: ": #GHC 7.10.2"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.3
-      compiler: ": #GHC 7.10.2"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
-
-before_install:
- - unset CC
- - export PATH=$HOME/.cabal/bin:/opt/alex/3.1.4/bin:/opt/happy/1.19.5/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
-
-install:
- - cabal --version
- - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
- - travis_retry cabal update -v
- - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - if [ $CABALVER = 1.16 ]; then cabal install Cabal; fi
- - cabal install gtk2hs-buildtools
- - cabal install --only-dependencies --enable-tests --enable-benchmarks -v
-
-# Here starts the actual work to be performed for the package under test;
-# any command which exits with a non-zero exit code causes the build to fail.
-script:
- - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
- - cabal build   # this builds all libraries and executables (including tests/benchmarks)
- - cabal test
- - cabal check
- - cabal sdist   # tests that a source-distribution can be generated
-
-# Check that the resulting source distribution can be built & installed.
-# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
-# `cabal install --force-reinstalls dist/*-*.tar.gz`
- - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
-   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
-
-# EOF
+  - env: GHCVER=8.6.5 CABALVER=2.4 STACK_YAML=stack-8.6.5.yaml
+    addons:
+      apt:
+        sources:
+        - hvr-ghc
+        packages:
+        - ghc-8.6.5
+  - env: GHCVER=8.4.4 CABALVER=2.4 STACK_YAML=stack-8.4.4.yaml
+    addons:
+      apt:
+        sources:
+        - hvr-ghc
+        packages:
+        - ghc-8.4.4
+  - env: GHCVER=8.2.2 CABALVER=2.0 STACK_YAML=stack-8.2.2.yaml
+    addons:
+      apt:
+        sources:
+        - hvr-ghc
+        packages:
+        - ghc-8.2.2
+  - env: GHCVER=8.0.2 CABALVER=1.24 STACK_YAML=stack-8.0.2.yaml
+    addons:
+      apt:
+        sources:
+        - hvr-ghc
+        packages:
+        - ghc-8.0.2

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -1,0 +1,5 @@
+resolver: lts-9.21
+packages:
+- '.'
+extra-deps:
+- svgcairo-0.13.2.1

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -1,0 +1,10 @@
+resolver: lts-11.22
+packages:
+- '.'
+extra-deps:
+- svgcairo-0.13.2.1
+- graphviz-2999.20.0.3
+- gtk3-0.15.4
+- gio-0.13.8.0
+- wl-pprint-text-1.2.0.0
+- base-compat-0.10.5

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -1,0 +1,5 @@
+resolver: lts-12.26
+packages:
+- '.'
+extra-deps:
+- svgcairo-0.13.2.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -1,0 +1,11 @@
+resolver: lts-14.20
+packages:
+- '.'
+extra-deps:
+- svgcairo-0.13.2.1
+- cairo-0.13.6.0
+- gtk3-0.15.4
+- gio-0.13.8.0
+- glib-0.13.8.0
+- gtk2hs-buildtools-0.13.8.0
+- pango-0.13.8.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,11 @@
+resolver: lts-14.20
+packages:
+- '.'
+extra-deps:
+- svgcairo-0.13.2.1
+- cairo-0.13.6.0
+- gtk3-0.15.4
+- gio-0.13.8.0
+- glib-0.13.8.0
+- gtk2hs-buildtools-0.13.8.0
+- pango-0.13.8.0

--- a/xdot.cabal
+++ b/xdot.cabal
@@ -1,13 +1,13 @@
 name:               xdot
-version:            0.3.0.1
+version:            0.3.0.2
 license:            BSD3
 license-file:       LICENSE
 category:           Graphs, Graphics
-cabal-version:      >= 1.10
+cabal-version:      >= 1.18
 build-type:         Simple
 author:             Dennis Felsing <dennis@felsin9.de>
 maintainer:         Dennis Felsing <dennis@felsin9.de>
-copyright:          Dennis Felsing 2012-2016
+copyright:          Dennis Felsing 2012-2019
 synopsis:           Parse Graphviz xdot files and interactively view them using GTK and Cairo
 description:        Parse Graphviz xdot files and interactively view them using
                     GTK and Cairo.
@@ -22,18 +22,18 @@ description:        Parse Graphviz xdot files and interactively view them using
                     is now a separate project, in case anyone else may have a
                     use for it.
 
-tested-with: GHC == 7.4.1, GHC == 7.4.2, GHC == 7.6.1, GHC == 7.6.2, GHC == 7.6.3, GHC == 7.8.3, GHC == 7.10.1, GHC == 7.10.2, GHC == 7.10.3
+tested-with: GHC == 8.0.2 || == 8.2.2 || == 8.4.4 || == 8.6.5
 Extra-source-files: dot-examples/*.dot
 Library
   Exposed-modules: Graphics.XDot.Parser Graphics.XDot.Viewer Graphics.XDot.Types
   Default-Language: Haskell2010
-  Build-depends: base == 4.*,
+  Build-depends: base >= 4.9.1 && < 4.13,
                  mtl >= 2.0 && < 2.3,
                  cairo >= 0.12 && < 0.14,
-                 gtk3 >= 0.12 && < 0.15,
-                 graphviz >= 2999.16 && < 2999.19,
+                 gtk3 >= 0.12 && < 0.16,
+                 graphviz >= 2999.16 && < 2999.21,
                  text >= 0.11 && < 1.3,
-                 polyparse >= 1.8 && < 1.13
+                 polyparse >= 1.8 && < 1.14
   Hs-source-dirs: src/
   Ghc-options: -Wall -fno-warn-unused-do-bind
 


### PR DESCRIPTION
This is the first of a series of PRs with the goal to build `ghc-vis` with current versions of GHC.

For this PR I just changed the `xdot.cabal` and `.travis.yml` files. There were no changes to the Haskell code.  In `.travis.yml` I changed to stack builds. That's much simpler.
