### PR TITLE
Avoid `cairoContextGetFontOptions`

### DIFF
--- a/src/Graphics/XDot/Viewer.hs
+++ b/src/Graphics/XDot/Viewer.hs
@@ -17,7 +17,7 @@ import Graphics.XDot.Types hiding (w, h, filled, alignment, text, name, size)
 import Graphics.UI.Gtk (PangoRectangle(..), layoutSetFontDescription,
   layoutGetExtents, layoutContextChanged, fontDescriptionFromString,
   fontDescriptionSetSize, showLayout, cairoContextSetFontOptions,
-  cairoContextGetFontOptions, layoutGetContext, createLayout)
+  layoutGetContext, createLayout)
 import Graphics.Rendering.Cairo hiding (x, y)
 
 import Control.Monad.State.Strict hiding (State)
@@ -159,8 +159,9 @@ draw hover (mn, Text (x,y) alignment w text) = do
   layout <- lift $ createLayout text
   context <- liftIO $ layoutGetContext layout
 
-  fo <- liftIO $ cairoContextGetFontOptions context
-
+  -- cannot use cairoContextGetFontOptions, as it may crash
+  -- see https://github.com/gtk2hs/gtk2hs/issues/258
+  fo <- fontOptionsCreate
   fontOptionsSetAntialias fo AntialiasDefault
   fontOptionsSetHintStyle fo HintStyleNone
   fontOptionsSetHintMetrics fo HintMetricsOff


### PR DESCRIPTION
as it can lead to crashes (https://github.com/gtk2hs/gtk2hs/issues/258)

Thanks to @rcook for the fix.