### PR TITLE
Bump `base` upper bound to work with GHC 9.0.2

### DIFF
--- a/xdot.cabal
+++ b/xdot.cabal
@@ -27,7 +27,7 @@ Extra-source-files: dot-examples/*.dot
 Library
   Exposed-modules: Graphics.XDot.Parser Graphics.XDot.Viewer Graphics.XDot.Types
   Default-Language: Haskell2010
-  Build-depends: base >= 4.9.1 && < 4.15,
+  Build-depends: base >= 4.9.1 && < 5,
                  mtl >= 2.0,
                  cairo >= 0.12,
                  gtk3 >= 0.12,


### PR DESCRIPTION
Background: 
> https://github.com/NixOS/nixpkgs/pull/160733#issuecomment-1047681179

`ghc-vis` build on nixpkgs was broken as its dependency `xdot` had a restrictive upper bound on base version 4.15. 

This PR bumps the said bound to 5. Using the diff here I was able to run `ghc-vis` again, so as far as I can tell `xdot` works fine as well.